### PR TITLE
Null check in the nodeImage attribute to allow nodes without images

### DIFF
--- a/index.js
+++ b/index.js
@@ -526,7 +526,7 @@ class TreeChart {
             }) => imageHeight)
             .attr('xlink:href', ({
                 data
-            }) => data.nodeImage || data.nodeImage.url)
+            }) => data.nodeImage && data.nodeImage.url)
             .attr('viewbox', ({
                 imageWidth,
                 imageHeight

--- a/index.js
+++ b/index.js
@@ -526,7 +526,7 @@ class TreeChart {
             }) => imageHeight)
             .attr('xlink:href', ({
                 data
-            }) => data.nodeImage === null ? null : data.nodeImage.url)
+            }) => data.nodeImage || data.nodeImage.url)
             .attr('viewbox', ({
                 imageWidth,
                 imageHeight

--- a/index.js
+++ b/index.js
@@ -526,7 +526,7 @@ class TreeChart {
             }) => imageHeight)
             .attr('xlink:href', ({
                 data
-            }) => data.nodeImage.url)
+            }) => data.nodeImage === null ? null : data.nodeImage.url)
             .attr('viewbox', ({
                 imageWidth,
                 imageHeight


### PR DESCRIPTION
Hi!

Great work! This (very) small change will allow having a node without the nodeImage attribute. I think this is the intention after having code like this in other places:
```js
if (d.data.nodeImage && d.data.nodeImage.width) {
                    imageWidth = d.data.nodeImage.width
                };
```

Cheers!