### PR TITLE
Remove Unsafe Calls to Eval()

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,11 +31,11 @@ class TreeChart {
         Object.keys(attrs).forEach((key) => {
             //@ts-ignore
             this[key] = function (_) {
-                var string = `attrs['${key}'] = _`;
                 if (!arguments.length) {
-                    return eval(`attrs['${key}'];`);
+                  return attrs[key];
+                } else {
+                  attrs[key] = _
                 }
-                eval(string);
                 return this;
             };
         });


### PR DESCRIPTION
closes #39 

Fixes unsafe eval to comply with CSP.

I am using `d3-organization-chart` in my project, however the [naked evals are unsafe](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#Never_use_eval!) and triggering [CSP errors](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src). I've updated to avoid use of eval in an unsafe way.